### PR TITLE
Update serverlist.txt so that by default all lines are comments

### DIFF
--- a/.servers/serverlist.txt
+++ b/.servers/serverlist.txt
@@ -1,3 +1,4 @@
-docker run -d --name bitwarden -v <full-local-path>\logs:/var/log/bitwarden -v <full-local-path>\bwdata:/etc/bitwarden -p 80:8080 --env-file <full-local-path>\settings.env bitwarden-patch
-<OR>
-docker-compose -f <full-local-path>/docker-compose.yml up -d
+# Uncomment a line below and fill in the missing values or add your own. Every line in this file will be called by build.[sh|ps1] once the patched image is built.
+# docker run -d --name bitwarden -v <full-local-path>\logs:/var/log/bitwarden -v <full-local-path>\bwdata:/etc/bitwarden -p 80:8080 --env-file <full-local-path>\settings.env bitwarden-patch
+# <OR>
+# docker-compose -f <full-local-path>/docker-compose.yml up -d


### PR DESCRIPTION
Right now the Unified branch has missing values intended to be filled in by the end user in serverlist.txt by default. If a user runs build.[sh|ps1] without changing the contents of serverlist.txt, the build script will call each line of serverlist.txt and attempt to execute in bash/powershell as is. A better approach is to make each line a comment by default and instruct the end user to uncomment the line once they have filled in the missing values. Both bash and powershell treat anything after a pound symbol (#) in a line as a comment, so start each line with a pound symbol. This ensures that by default when each line is called by build.[sh|ps1] the example commands are not actually executed by bash/powershell.