### PR TITLE
Clean up workflows

### DIFF
--- a/.github/workflows/build-packages.yaml
+++ b/.github/workflows/build-packages.yaml
@@ -13,22 +13,25 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: BitBetter
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push images
         run: |
-          git clone --single-branch --branch unified https://github.com/Jgigantino31/BitBetter.git
-          cd BitBetter
           ./build.sh y
+          BW_VERSION=$(curl -sL https://go.btwrdn.co/bw-sh-versions | grep '^ *"'coreVersion'":' | awk -F\: '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
           docker tag bitwarden-patch:latest ghcr.io/jgigantino31/bitwarden-patch:latest
+          docker tag bitwarden-patch:latest ghcr.io/jgigantino31/bitwarden-patch:BW_VERSION
           docker tag bitbetter/licensegen:latest ghcr.io/jgigantino31/licensegen:latest
+          docker tag bitbetter/licensegen:latest ghcr.io/jgigantino31/licensegen:BW_VERSION
           docker push ghcr.io/jgigantino31/bitwarden-patch:latest
+          docker push ghcr.io/jgigantino31/bitwarden-patch:BW_VERSION
           docker push ghcr.io/jgigantino31/licensegen:latest
+          docker push ghcr.io/jgigantino31/licensegen:BW_VERSION

--- a/.github/workflows/update-check.yaml
+++ b/.github/workflows/update-check.yaml
@@ -9,12 +9,16 @@ jobs:
   check:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      packages: read
       actions: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Check if update available
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check if base image has been updated
         id: check
         uses: lucacome/docker-image-update-checker@v2
         with:
@@ -33,5 +37,5 @@ jobs:
     permissions:
       actions: write
     steps:
-      - name: Keep alive
+      - name: Keep scheduled workflow alive
         uses: liskin/gh-workflow-keepalive@v1


### PR DESCRIPTION
Updated Github Actions workflows. Update Check workflow now logs into ghcr.io to remove warnings and does not checkout repository as there is no need to. Build Packages workflow now actually uses the repository checked out in action/checkout instead of using git clone in the last step. Also create BW_VERSION variable from the latest Bitwarden core version information and tag builds with the version (ex. 2025.6.1) in addition to latest.